### PR TITLE
Guard against overriding window's native FormData accidentally

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,9 @@
-global.FormData = module.exports = require('form-data')
+const formData = require('form-data');
+
+let hasWindow = true;
+try { window } catch { hasWindow = false }
+if (!hasWindow) {
+  global.FormData = formData
+}
+
+module.exports = formData;


### PR DESCRIPTION
This is to address an issue when using `twilio-chat` Electron. `twilio-chat` depends on `isomorphic-form-data`, which updates global (aka window) in Electron.