### PR TITLE
feat: use globalThis to assign/access FormData

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,1 +1,1 @@
-module.exports = window.FormData
+module.exports = globalThis.FormData

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,1 @@
-global.FormData = module.exports = require('form-data')
+globalThis.FormData = module.exports = require('form-data')


### PR DESCRIPTION
BREAKING CHANGE: globalThis is a new standardized way how to access
global object. This commit is a breaking change for older node.js
and browser versions not supporting this standard. It allows
us to use this libraries in different contexts: node.js, worker, window, frames.

More info: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis